### PR TITLE
优化 Collection::where 操作符大小写

### DIFF
--- a/library/think/Collection.php
+++ b/library/think/Collection.php
@@ -353,7 +353,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate, JsonSeria
                 $result = isset($data[$field]) ? $data[$field] : null;
             }
 
-            switch ($operator) {
+            switch (strtolower($operator)) {
                 case '===':
                     return $result === $value;
                 case '!==':


### PR DESCRIPTION
开发时发现以下语句返回的结果并非预期：

```
$collection->where('id', 'IN', [1, 2]);
```

实际返回结果应该含有2个，但实际为空。